### PR TITLE
Upgrading to python 3.5 while remaining compatible with 2.7

### DIFF
--- a/battle.py
+++ b/battle.py
@@ -67,7 +67,7 @@ class Battle():
                     return -1
                 if event.type == pygame.KEYDOWN:
                     if event.key == pygame.K_RETURN:
-                        print "saving screenshot"
+                        print("saving screenshot")
                         pygame.image.save(screen,settingsManager.createPath('screenshot.jpg'))
                     
                     for fight in currentFighters:
@@ -126,11 +126,11 @@ class Battle():
     
     def doExitStatus(self,exitStatus):
         if exitStatus == 1:
-            print "NO CONTEST"
+            print("NO CONTEST")
         elif exitStatus == 2:
-            print "GAME SET"
+            print("GAME SET")
         elif exitStatus == -1:
-            print "ERROR!"
+            print("ERROR!")
          
     """
     In a normal game, the frame input won't matter.

--- a/engine/abstractFighter.py
+++ b/engine/abstractFighter.py
@@ -262,10 +262,10 @@ class AbstractFighter():
         self.changeAction(baseActions.LedgeGrab(ledge))
         
     def doLedgeGetup(self):
-        print "getup"
+        print("getup")
         
     def doGetTrumped(self):
-        print "trumped"
+        print("trumped")
         
 ########################################################
 #                  STATE CHANGERS                      #
@@ -336,7 +336,7 @@ class AbstractFighter():
                 if totalKB < 30: trajectory = 0
                 else: trajectory = 43
             else: trajectory = 43
-            print trajectory
+            print(trajectory)
             
         #Directional Incluence
         if (trajectory < 45 or trajectory > 315) or (trajectory < 225 and trajectory > 135):
@@ -344,7 +344,7 @@ class AbstractFighter():
                 trajectory += 15
             if self.keysContain('down'):
                 trajectory -= 15
-        print totalKB, trajectory
+        print(totalKB, trajectory)
         self.setSpeed(totalKB, trajectory, False)
         self.preferred_xspeed = 0
         self.preferred_yspeed = 0

--- a/engine/baseActions.py
+++ b/engine/baseActions.py
@@ -64,7 +64,7 @@ class Stop(action.Action):
     def stateTransitions(self, actor):
         (key,invkey) = actor.getForwardBackwardKeys()
         if actor.bufferContains(key,12,andReleased=True) and actor.keysContain(key):
-            print "run"
+            print("run")
             actor.doGroundMove(actor.getFacingDirection(),True)
         if actor.bufferContains(invkey,5,notReleased = True):
             actor.doPivot()
@@ -91,7 +91,7 @@ class HitStun(action.Action):
     def update(self,actor):
         if self.frame == 0:
             (direct,mag) = actor.getDirectionMagnitude()
-            print "direction:", direct
+            print("direction:", direct)
             if direct != 0 and direct != 180:
                 actor.grounded = False
                 if mag > 10:
@@ -166,7 +166,7 @@ class Land(action.Action):
         if self.frame == 0:
             self.lastFrame = actor.landingLag
             if actor.bufferContains('shield',distanceBack=22):
-                print "l-cancel"
+                print("l-cancel")
                 self.lastFrame = self.lastFrame / 2    
         if self.frame == self.lastFrame:
             actor.landingLag = 6
@@ -358,7 +358,7 @@ def moveState(actor, direction):
     if actor.bufferContains(key, state=0):
         actor.doStop()
     if actor.bufferContains('attack'):
-        print "attacking"
+        print("attacking")
         actor.doGroundAttack()
             
 def shieldState(actor):
@@ -378,7 +378,7 @@ def shieldState(actor):
 def ledgeState(actor):
     (key,invkey) = actor.getForwardBackwardKeys()
     if actor.bufferContains(key):
-        print "up"
+        print("up")
         actor.doLedgeGetup
     elif actor.bufferContains(invkey):
         actor.ledgeLock = True

--- a/engine/basicFighter.py
+++ b/engine/basicFighter.py
@@ -98,10 +98,10 @@ class BasicFighter():
         self.changeAction(self.actions.LedgeGrab(ledge))
         
     def doLedgeGetup(self):
-        print "getup"
+        print("getup")
         
     def doGetTrumped(self):
-        print "trumped"
+        print("trumped")
         
 ########################################################
 #                  STATE CHANGERS                      #

--- a/engine/hitbox.py
+++ b/engine/hitbox.py
@@ -37,7 +37,7 @@ class DamageHitbox(Hitbox):
     def onCollision(self,other):
         if other.lockHitbox(self,self.hitstun):
             other.applyKnockback(self.damage, self.baseKnockback, self.knockbackGrowth, self.trajectory)
-            print other.damage
+            print(other.damage)
         
     def update(self):
         Hitbox.update(self)

--- a/fighters/hitboxie/hitboxie.py
+++ b/fighters/hitboxie/hitboxie.py
@@ -83,11 +83,11 @@ class Hitboxie(abstractFighter.AbstractFighter):
         self.changeAction(self.actions.LedgeGrab(ledge))
         
     def doGroundAttack(self):
-        print 'player ', self.playerNum, ' attacking'
+        print('player ', self.playerNum, ' attacking')
         (key, invkey) = self.getForwardBackwardKeys()
         if self.keysContain(key):
             if self.checkSmash(key):
-                print "SMASH!"
+                print("SMASH!")
                 self.changeAction(self.actions.ForwardSmash())
             else:
                 self.changeAction(self.actions.ForwardAttack())

--- a/fighters/hitboxie/hitboxie_actions.py
+++ b/fighters/hitboxie/hitboxie_actions.py
@@ -181,7 +181,7 @@ class ForwardSmash(action.Action):
             actor.changeSpriteImage(2)
         elif self.frame == 8:
             if actor.keysContain('attack') and self.chargeLevel <= 5:
-                print "charging..."
+                print("charging...")
                 self.chargeLevel += 1
                 self.fSmashHitbox.damage += 1
                 self.fSmashHitbox.baseKnockback += 0.05

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pygame
 import stages.stage
 import stages.true_arena as stage
@@ -109,7 +110,7 @@ def importFromURI(file, uri, absl=False):
         try:
             return imp.load_source(mname, no_ext + '.py')
         except Exception as e:
-            print mname, e
+            print(mname, e)
         
     
 if __name__  == '__main__': main(True)

--- a/menu/menu.py
+++ b/menu/menu.py
@@ -115,7 +115,7 @@ class MainMenu(SubMenu):
         clock = pygame.time.Clock()
         
         controls = settingsManager.getControls('menu')
-        print controls.keyBindings
+        print(controls.keyBindings)
         
         while self.status == 0:
             self.update(screen)
@@ -419,7 +419,7 @@ class GameSettingsMenu(SubMenu):
         self.presets = self.settings['presetLists']
         
         self.current_preset = self.presets.index(self.settings['current_preset'])
-        print self.current_preset
+        print(self.current_preset)
         self.selectionSlice = (0,10)
         
         self.selectedOption = 0
@@ -646,7 +646,7 @@ class OptionButton(spriteManager.TextSprite):
         if startingVal in vals:
             self.selectedValue = self.possibleVals.index(startingVal) 
         else:
-            print "Not in list of options"
+            print("Not in list of options")
             self.selectedValue = 0
         
         self.nameText = spriteManager.TextSprite(name, 'rexlia rg',18,[100,100,100])

--- a/musicManager.py
+++ b/musicManager.py
@@ -22,7 +22,7 @@ class musicManager():
     
     def rollMusic(self):
         roll = random.randint(0,self.getTotalChance())
-        print roll, self.getTotalChance()
+        print(roll, self.getTotalChance())
         for path, chance, name in self.musicList:
             roll -= chance
             if roll <= 0:

--- a/settingsManager.py
+++ b/settingsManager.py
@@ -1,8 +1,13 @@
+from __future__ import print_function
 import pygame.constants
 import re
 import os
 import imp
-from ConfigParser import SafeConfigParser
+try:
+    from configparser import SafeConfigParser
+except ImportError:
+    from ConfigParser import SafeConfigParser
+
 
 settings = None
 sfxLib = None
@@ -46,7 +51,7 @@ def importFromURI(filePath, uri, absl=False, suffix=""):
         try:
             return imp.load_source((mname + suffix), no_ext + '.py')
         except Exception as e:
-            print mname, e
+            print(mname, e)
 
 """
 Build the settings if they do not exist yet, otherwise, get a setting.
@@ -107,7 +112,7 @@ class Settings():
     def __init__(self):
         self.KeyIdMap = {}
         self.KeyNameMap = {}
-        for name, value in vars(pygame.constants).iteritems():
+        for name, value in vars(pygame.constants).items():
             if name.startswith("K_"):
                 self.KeyIdMap[value] = name
                 self.KeyNameMap[name] = value
@@ -121,7 +126,7 @@ class Settings():
         # Getting the window information
         
         self.setting['windowName']    = getString(self.parser,'window','windowName')
-        self.setting['windowSize']    = getNumber(self.parser, 'window', 'windowSize',True) 
+        self.setting['windowSize']    = getNumber(self.parser, 'window', 'windowSize',True)
         self.setting['windowWidth']   = self.setting['windowSize'][0]
         self.setting['windowHeight']  = self.setting['windowSize'][1]
         self.setting['frameCap']      = getNumber(self.parser, 'window', 'frameCap')
@@ -186,7 +191,7 @@ class Settings():
         self.setting['freeDodgeSpecialFall'] = getBoolean(preset_parser, preset, 'freeDodgeSpecialFall')
         self.setting['enableWavedash'] = getBoolean(preset_parser, preset, 'enableWavedash')        
     
-        print self.setting
+        print(self.setting)
     
     def loadControls(self):
         # load menu controls first
@@ -196,7 +201,7 @@ class Settings():
         if controlType == 'gamepad': # If the controls are set to Gamepad
             gamepadName = self.parser.get(groupName, 'gamepad')
             if gamepadName in self.setting['controllers']: # Check if that Gamepad is connected
-                print "okay", gamepadName
+                print("okay", gamepadName)
                 bindings = {
                     getGamepadTuple(self.parser, gamepadName, 'left') : 'left',
                     getGamepadTuple(self.parser, gamepadName, 'right') : 'right',
@@ -206,7 +211,7 @@ class Settings():
                     getGamepadTuple(self.parser, gamepadName, 'cancel') : 'cancel'
                 }
             else: # If it is not connected, use the buttons instead.
-                print "error", gamepadName
+                print("error", gamepadName)
                 bindings = {}
             
         # If the bindings are empty (as in, not set by the Gamepad)
@@ -230,7 +235,7 @@ class Settings():
             if controlType == 'gamepad': # If the controls are set to Gamepad
                 gamepadName = self.parser.get(groupName, 'gamepad')
                 if gamepadName in self.setting['controllers']: # Check if that Gamepad is connected
-                    print "okay", gamepadName
+                    print("okay", gamepadName)
                     bindings = {
                         getGamepadTuple(self.parser, gamepadName, 'left') : 'left',
                         getGamepadTuple(self.parser, gamepadName, 'right') : 'right',
@@ -242,7 +247,7 @@ class Settings():
                         getGamepadTuple(self.parser, gamepadName, 'shield') : 'shield',
                         }
                 else: # If it is not connected, use the buttons instead.
-                    print "error", gamepadName
+                    print("error", gamepadName)
                     bindings = {}
             
             # If the bindings are empty (as in, not set by the Gamepad)
@@ -387,7 +392,7 @@ first number.
 """
 def getNumbersFromString(string, many = False):
     if many:
-        return map(int, re.findall(r'\d+', string))
+        return list(map(int, re.findall(r'\d+', string)))
     else:
         return int(re.search(r'\d+', string).group())
 
@@ -406,8 +411,8 @@ A wrapper that'll get a lowercase String from the parser, or return gracefully w
 def getString(parser,preset,key):
     try:
         return parser.get(preset,key).lower()
-    except Exception,e:
-        print e
+    except (Exception,e):
+        print(e)
         return ""
 
 """
@@ -416,8 +421,8 @@ A wrapper that'll get a boolean from the parser, or return gracefully with an er
 def getBoolean(parser,preset,key):
     try:
         return boolean(parser.get(preset,key))
-    except Exception,e:
-        print e
+    except (Exception,e):
+        print(e)
         return False
 
 """
@@ -426,8 +431,8 @@ A wrapper that'll get a number from the parser, or return gracefully with an err
 def getNumber(parser,preset,key,islist = False):
     try:
         return getNumbersFromString(parser.get(preset,key),islist)
-    except Exception,e:
-        print e
+    except (Exception,e):
+        print(e)
         return 0
 
 """
@@ -443,15 +448,15 @@ def getGamepadTuple(parser,preset,key):
         joyInfo = parser.get(preset,key).split(' ')
         if len(joyInfo) < 3: joyInfo.append('')
         return (joyInfo[0], getNumbersFromString(joyInfo[1],False),joyInfo[2]) 
-    except Exception,e:
-        print e
+    except (Exception,e):
+        print(e)
         return ("",0)
 
 """
 Main method for debugging purposes
 """
 def test():
-    print getSetting().setting
+    print(getSetting().setting)
     
 
 if __name__  == '__main__': test()

--- a/spriteManager.py
+++ b/spriteManager.py
@@ -16,8 +16,8 @@ class Sprite(pygame.sprite.Sprite):
         try:
             blitSprite = pygame.transform.smoothscale(self.image, (w,h))
         except Exception as e:
-            print e
-            print "Please use 32-bit PNG files"
+            print(e)
+            print("Please use 32-bit PNG files")
             sys.exit()
         if self.angle != 0:
             blitSprite = pygame.transform.rotate(blitSprite,self.angle)
@@ -69,9 +69,9 @@ class SpriteHandler(Sprite):
     
     def get_image(self):
         try:
-            self.image = self.imageLibrary[self.flip][self.currentSheet][self.index]
+            self.image = self.imageLibrary[self.flip][self.currentSheet][int(self.index)]
         except:
-            print "Error loading sprite ", self.currentSheet, " Loading default"
+            print("Error loading sprite ", self.currentSheet, " Loading default")
             self.image = self.imageLibrary[self.flip][self.startingImage][0]
         
         self.rect = self.image.get_rect(center=self.rect.center)
@@ -85,7 +85,7 @@ class SpriteHandler(Sprite):
     def buildImageLibrary(self,lib,offset):
         library = {}
         flippedLibrary = {}
-        for key,value in lib.imageDict.iteritems():
+        for key,value in lib.imageDict.items():
             imageList = self.buildSubimageList(value,offset)
             library[key] = imageList
             flipList = []
@@ -103,8 +103,8 @@ class SpriteHandler(Sprite):
         while index < sheet.get_width() / offset:
             sheet.set_clip(pygame.Rect(index * offset, 0, offset,sheet.get_height()))
             image = sheet.subsurface(sheet.get_clip())
-            for fromColor,toColor in self.colorMap.iteritems():
-                self.recolor(image, list(fromColor), list(toColor))
+            for fromColor,toColor in self.colorMap.items():
+                self.recolor(image, tuple(list(fromColor)), tuple(list(toColor)))
             imageList.append(image)
             index += 1
         return imageList
@@ -168,8 +168,8 @@ class SheetSprite(ImageSprite):
             self.sheet.set_clip(pygame.Rect(index * offset, 0, offset,sheet.get_height()))
             image = sheet.subsurface(sheet.get_clip())
             #image = image.convert_alpha()
-            for fromColor,toColor in self.colorMap.iteritems():
-                self.recolor(image, list(fromColor), list(toColor))
+            for fromColor,toColor in self.colorMap.items():
+                self.recolor(image, tuple(list(fromColor)), tuple(list(toColor)))
             imageList.append(image)
             index += 1
         return imageList
@@ -275,7 +275,7 @@ class ImageLibrary():
                 sprite = pygame.image.load(os.path.join(self.directory,f))
                 sprite = sprite.convert_alpha()
                 self.imageDict[spriteName] = sprite
-                print sprite.get_alpha(), spriteName, self.imageDict[spriteName]
+                print(sprite.get_alpha(), spriteName, self.imageDict[spriteName])
 
 class RectSprite(Sprite):
     def __init__(self,rect,color=[0,0,0]):

--- a/stages/stage.py
+++ b/stages/stage.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pygame
 import spriteObject
 import settingsManager
@@ -201,7 +202,7 @@ class Stage():
             if abs(h - w) <= 0.02:
                 # Fuck it, close enough.
                 return h
-            print "Scaling Error", h, w, abs(h-w)
+            print("Scaling Error", h, w, abs(h-w))
             return w
         
     """


### PR DESCRIPTION
Hi, I just took a copy of the code to try upgrade it to python 3. It's fully backwards compatible with 2.7, so it shouldn't make any differences to the original code. I just thought it would be useful considering there were a few comments about python 3 on the smash bros subreddit. 

The changes are largely mechanical, replacing "print" with "print ()", same with exceptions, casting division and changing a few iterators/types to alternatives that work on both python 2.7 and python 3.5
